### PR TITLE
Modifies logic to hide datepicker when clicking browser back button

### DIFF
--- a/input.js
+++ b/input.js
@@ -89,12 +89,6 @@ export default class Input {
     });
   }
 
-  // when used in a single-page app,
-  // hide datepicker when the browser's back button is pressed
-  this.element.addEventListener("hashchange", () => {
-    thePicker.hide();
-  })
-
   getLocaleText() {
     const locale = this.locale.toLowerCase();
 

--- a/picker.js
+++ b/picker.js
@@ -114,9 +114,6 @@ class Picker {
 
   // Hide.
   hide() {
-    // clear interval when datepicker is hides.
-    clearInterval(compareHrefInterval);
-
     this.container.setAttribute(`data-open`, this.isOpen = false);
     // Close the picker when clicking outside of a date input or picker.
     if(this.input) { this.input.blur() }
@@ -135,13 +132,9 @@ class Picker {
 
     // when used in a single-page app  or otherwise,
     // hide datepicker when the browser's back button is pressed
-    let currentPage = window.location.href;
-    compareHrefInterval = setInterval(() => {
-      console.log('in setinterval');
-      if (currentPage != window.location.href) {
-        thePicker.hide();
-      }
-    }, 100);
+    window.onpopstate = () => {
+      this.hide();
+    }
   }
 
   // Position picker below element. Align to element's right edge.

--- a/picker.js
+++ b/picker.js
@@ -114,6 +114,9 @@ class Picker {
 
   // Hide.
   hide() {
+    // clear interval when datepicker is hides.
+    clearInterval(compareHrefInterval);
+
     this.container.setAttribute(`data-open`, this.isOpen = false);
     // Close the picker when clicking outside of a date input or picker.
     if(this.input) { this.input.blur() }
@@ -129,6 +132,16 @@ class Picker {
       document.addEventListener(`mousedown`, this.removeClickOut);
       document.addEventListener(`touchstart`, this.removeClickOut);
     }, 500);
+
+    // when used in a single-page app  or otherwise,
+    // hide datepicker when the browser's back button is pressed
+    let currentPage = window.location.href;
+    compareHrefInterval = setInterval(() => {
+      console.log('in setinterval');
+      if (currentPage != window.location.href) {
+        thePicker.hide();
+      }
+    }, 100);
   }
 
   // Position picker below element. Align to element's right edge.


### PR DESCRIPTION
 - moved logic into the show() function in picker.js
 - used setTimeout and clearInterval instead of the onhashchange event
  * reason: onhashchange event only listens to urls containing a `#` symbol.